### PR TITLE
GUNDI-4109: `sensor_featured_properties` approach (with unit tests)

### DIFF
--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -1,6 +1,6 @@
 import pydantic
 
-from typing import Any
+from typing import Any, List, Optional
 from datetime import datetime, timezone
 
 from app.actions.core import AuthActionConfiguration, PullActionConfiguration, ExecutableActionMixin, InternalActionConfiguration
@@ -31,6 +31,10 @@ class PullObservationsConfig(PullActionConfiguration):
             widget="range",  # This will be rendered ad a range slider
         )
     )
+    sensor_featured_properties: Optional[List[str]] = pydantic.Field(
+        title='Featured Readings',
+        description='A comma-separated list of sensor data to display as "featured_property" in ER. (format: SENSOR_NAME: DATA_TYPE_1, DATA_TYPE_2, ...)',
+    )
 
 
 class PullSensorObservationsPerStationConfig(InternalActionConfiguration):
@@ -38,6 +42,7 @@ class PullSensorObservationsPerStationConfig(InternalActionConfiguration):
     stop: datetime
     project_id: int
     station: dict
+    sensor_featured_properties: list
     sensor: Any
     units: Any
 

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -197,7 +197,7 @@ async def action_pull_sensor_observations_per_station(integration, action_config
                     f"Extracted {len(readings)} readings for sensor '{action_config.sensor['name']}' from '{timestamp}'"
                 )
 
-                transformed_data.append(transform(action_config, action_config.sensor_featured_properties ,timestamp, readings))
+                transformed_data.append(transform(action_config, action_config.sensor_featured_properties, timestamp, readings))
 
             for i, batch in enumerate(generate_batches(transformed_data, 200)):
                 logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Sensor: {action_config.sensor["name"]}')

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -26,7 +26,18 @@ def generate_date_pairs(lower_date, upper_date, interval=MAX_DAYS_PER_QUERY):
         upper_date -= timedelta(days=interval)
 
 
-def transform(station_sensor, timestamp, readings):
+def parse_sensor_featured_properties(data_to_display):
+    result = {}
+    for entry in data_to_display:
+        if ':' in entry:
+            key, values = entry.split(':', 1)
+            key = key.strip()
+            values_list = [v.strip() for v in values.split(',')]
+            result[key] = values_list
+    return result
+
+
+def transform(station_sensor, featured_properties_to_display, timestamp, readings):
     if station_sensor.station['station_name'] == station_sensor.sensor['name']:
         # Sensor info is related to the station
         source_name = f"Station {station_sensor.station['station_name']}"
@@ -47,6 +58,16 @@ def transform(station_sensor, timestamp, readings):
 
         readings_additional.update(reading_additional)
 
+    if featured_properties_to_display:
+        readings_str = ', '.join(
+            f"{k}: {readings_additional[k]}" for k in featured_properties_to_display if k in readings_additional
+        )
+        if not readings_str:
+            # sensor names set in config are not found in readings, show everything
+            readings_str = ', '.join(f"{k}: {v}" for k, v in readings_additional.items())
+    else:
+        readings_str = ', '.join(f"{k}: {v}" for k, v in readings_additional.items())
+
     return {
         "source_name": source_name,
         "source": station_sensor.sensor["id"],
@@ -57,7 +78,7 @@ def transform(station_sensor, timestamp, readings):
             "lat": station_sensor.station['station_latitude'],
             "lon": station_sensor.station['station_longitude'],
         },
-        "additional": {**readings_additional}
+        "additional": {**readings_additional, "readings": readings_str}
     }
 
 
@@ -84,6 +105,9 @@ async def action_pull_observations(integration, action_config: PullObservationsC
 
     base_url = integration.base_url or STEVENS_CONNECT_BASE_URL
     auth_config = get_auth_config(integration)
+
+    # "featured_property" info (is present)
+    featured_properties_to_display = parse_sensor_featured_properties(action_config.sensor_featured_properties) if action_config.sensor_featured_properties else {}
 
     try:
         projects = await client.get_projects(integration, base_url, auth_config)
@@ -120,6 +144,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
                             start_date = dp(device_state.get("updated_at")).replace(tzinfo=timezone.utc)
 
                         stop_date = datetime.now(timezone.utc)
+                        sensor_featured_properties = featured_properties_to_display.get(sensor.name, [])
 
                         # Generate date pairs for the given start and stop dates
                         for lower, upper in generate_date_pairs(start_date, stop_date):
@@ -128,6 +153,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
                                 stop=upper,
                                 project_id=project.id,
                                 station=station_info,
+                                sensor_featured_properties=sensor_featured_properties,
                                 sensor=sensor,
                                 units=projects.units
                             )
@@ -171,7 +197,7 @@ async def action_pull_sensor_observations_per_station(integration, action_config
                     f"Extracted {len(readings)} readings for sensor '{action_config.sensor['name']}' from '{timestamp}'"
                 )
 
-                transformed_data.append(transform(action_config, timestamp, readings))
+                transformed_data.append(transform(action_config, action_config.sensor_featured_properties ,timestamp, readings))
 
             for i, batch in enumerate(generate_batches(transformed_data, 200)):
                 logger.info(f'Sending observations batch #{i}: {len(batch)} observations. Sensor: {action_config.sensor["name"]}')

--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -1,0 +1,154 @@
+import pytest
+import httpx
+
+from unittest.mock import patch, AsyncMock, MagicMock
+from app.actions import client
+
+@pytest.mark.asyncio
+async def test_get_token_good():
+    integration = MagicMock()
+    integration.id = "int1"
+    auth = MagicMock()
+    auth.email = "test@example.com"
+    auth.password.get_secret_value.return_value = "pw"
+    base_url = "https://api.stevens-connect.com"
+
+    response_data = {"data": {"token": "abc123"}}
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.return_value.is_error = False
+        mock_post.return_value.json = MagicMock(return_value=response_data)
+        mock_post.return_value.raise_for_status.return_value = None
+        token = await client.get_token(integration, base_url, auth)
+        assert token == "abc123"
+
+@pytest.mark.asyncio
+async def test_get_token_bad_400():
+    integration = MagicMock()
+    auth = MagicMock()
+    base_url = "url"
+    error = httpx.HTTPStatusError("msg", request=MagicMock(), response=MagicMock(status_code=400))
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.side_effect = error
+        with pytest.raises(client.StevensConnectBadRequestException):
+            await client.get_token(integration, base_url, auth)
+
+@pytest.mark.asyncio
+async def test_get_token_bad_404():
+    integration = MagicMock()
+    auth = MagicMock()
+    base_url = "url"
+    error = httpx.HTTPStatusError("msg", request=MagicMock(), response=MagicMock(status_code=404))
+    with patch("httpx.AsyncClient.post", new_callable=AsyncMock) as mock_post:
+        mock_post.side_effect = error
+        with pytest.raises(client.StevensConnectNotFoundException):
+            await client.get_token(integration, base_url, auth)
+
+@pytest.mark.asyncio
+async def test_get_projects_good():
+    integration = MagicMock()
+    integration.id = "int1"
+    base_url = "url"
+    auth = MagicMock()
+    token = "abc"
+    response_data = {"data": {"config_packet": {"projects": [], "units": []}}}
+    with patch("app.actions.client.get_token", new_callable=AsyncMock, return_value=token), \
+         patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get, \
+         patch("app.actions.client.ProjectResponse.parse_obj", return_value="parsed") as mock_parse:
+        mock_get.return_value.is_error = False
+        mock_get.return_value.json = MagicMock(return_value=response_data)
+        mock_get.return_value.raise_for_status.return_value = None
+        result = await client.get_projects(integration, base_url, auth)
+        assert result == "parsed"
+
+@pytest.mark.asyncio
+async def test_get_projects_bad_401():
+    async def test_get_projects_bad_401():
+        integration = MagicMock()
+        base_url = "url"
+        auth = MagicMock()
+        token = "abc"
+        error = httpx.HTTPStatusError(
+            "msg", request=MagicMock(), response=MagicMock(status_code=401)
+        )
+        with patch("app.actions.client.get_token", new_callable=AsyncMock, return_value=token), \
+                patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=error):
+            with pytest.raises(client.StevensConnectUnauthorizedException):
+                await client.get_projects(integration, base_url, auth)
+
+@pytest.mark.asyncio
+async def test_get_projects_bad_404():
+    integration = MagicMock()
+    base_url = "url"
+    auth = MagicMock()
+    token = "abc"
+    error = httpx.HTTPStatusError("msg", request=MagicMock(), response=MagicMock(status_code=404))
+    with patch("app.actions.client.get_token", new_callable=AsyncMock, return_value=token), \
+         patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get:
+        mock_get.side_effect = error
+        with pytest.raises(client.StevensConnectNotFoundException):
+            await client.get_projects(integration, base_url, auth)
+
+@pytest.mark.asyncio
+async def test_get_sensor_readings_good():
+    integration = MagicMock()
+    base_url = "url"
+    config = MagicMock()
+    config.project_id = "pid"
+    config.sensor = {"channels": [{"id": "cid"}], "name": "sname"}
+    config.start.strftime.return_value = "2024-01-01 00:00:00"
+    config.stop.strftime.return_value = "2024-01-02 00:00:00"
+    token = "abc"
+    response_data = {
+        "data": {
+            "readings": {"2024-01-01T00:00:00Z": []},
+            "paging": {"last_page": 1}
+        }
+    }
+    with patch("app.actions.client.get_auth_config", return_value=MagicMock()), \
+         patch("app.actions.client.get_token", new_callable=AsyncMock, return_value=token), \
+         patch("httpx.AsyncClient.get", new_callable=AsyncMock) as mock_get, \
+         patch("app.actions.client.ChannelReadingsResponse.parse_obj") as mock_parse:
+        mock_get.return_value.is_error = False
+        mock_get.return_value.json = MagicMock(return_value=response_data)
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_parse.return_value.readings = {"2024-01-01T00:00:00Z": []}
+        mock_parse.return_value.paging = {"last_page": 1}
+        result = await client.get_sensor_readings(integration, base_url, config)
+        assert isinstance(result, dict)
+
+@pytest.mark.asyncio
+async def test_get_sensor_readings_bad_401():
+    async def test_get_sensor_readings_bad_401():
+        integration = MagicMock()
+        base_url = "url"
+        config = MagicMock()
+        config.project_id = "pid"
+        config.sensor = {"channels": [{"id": "cid"}], "name": "sname"}
+        config.start.strftime.return_value = "2024-01-01 00:00:00"
+        config.stop.strftime.return_value = "2024-01-02 00:00:00"
+        token = "abc"
+        error = httpx.HTTPStatusError("msg", request=MagicMock(), response=MagicMock(status_code=401))
+        with patch("app.actions.client.get_auth_config", return_value=MagicMock()), \
+                patch("app.actions.client.get_token", new_callable=AsyncMock, return_value=token), \
+                patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=error):
+            with pytest.raises(client.StevensConnectUnauthorizedException):
+                await client.get_sensor_readings(integration, base_url, config)
+
+@pytest.mark.asyncio
+async def test_get_sensor_readings_bad_404():
+    integration = MagicMock()
+    base_url = "url"
+    config = MagicMock()
+    config.project_id = "pid"
+    config.sensor = {"channels": [{"id": "cid"}], "name": "sname"}
+    config.start.strftime.return_value = "2024-01-01 00:00:00"
+    config.stop.strftime.return_value = "2024-01-02 00:00:00"
+    token = "abc"
+    error = httpx.HTTPStatusError(
+        "msg", request=MagicMock(), response=MagicMock(status_code=404)
+    )
+    with patch("app.actions.client.get_auth_config", return_value=MagicMock()), \
+            patch("app.actions.client.get_token", new_callable=AsyncMock, return_value=token), \
+            patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=error):
+        with pytest.raises(client.StevensConnectNotFoundException):
+            await client.get_sensor_readings(integration, base_url, config)

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1,0 +1,161 @@
+import pytest
+
+from unittest.mock import AsyncMock, patch, MagicMock
+from app.actions import handlers
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_good(mocker, mock_publish_event):
+    integration = MagicMock()
+    integration.id = "int1"
+    integration.base_url = None
+
+    action_config = MagicMock()
+    action_config.sensor_featured_properties = ["Sensor1: Temp, Humidity"]
+    action_config.default_lookback_days = 2
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+
+    # Mock dependencies
+    with patch("app.actions.handlers.get_auth_config", return_value=MagicMock()), \
+         patch("app.actions.handlers.client.get_projects", new_callable=AsyncMock) as mock_get_projects, \
+         patch("app.actions.handlers.trigger_action", new_callable=AsyncMock), \
+         patch("app.actions.handlers.state_manager.get_state", new_callable=AsyncMock, return_value=None), \
+         patch("app.actions.handlers.state_manager.set_state", new_callable=AsyncMock):
+
+        # Setup mock projects, stations, sensors, units
+        sensor = MagicMock()
+        sensor.name = "Sensor1"
+        sensor.id = "sensor1"
+        sensor.channels = [MagicMock(channel_health={"last_reading": "2024-01-01 00:00:00 (UTC)"})]
+
+        station = MagicMock()
+        station.name = "Station1"
+        station.longitude = 1.0
+        station.latitude = 2.0
+        station.sensors = [sensor]
+
+        project = MagicMock()
+        project.id = 123
+        project.stations = [station]
+
+        projects = MagicMock()
+        projects.projects = [project]
+        projects.units = []
+
+        mock_get_projects.return_value = projects
+
+        result = await handlers.action_pull_observations(integration, action_config)
+        assert result["sensors_triggered"] == 2
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_bad_no_projects(mocker, mock_publish_event):
+    integration = MagicMock()
+    integration.id = "int1"
+    integration.base_url = None
+
+    action_config = MagicMock()
+    action_config.sensor_featured_properties = None
+    action_config.default_lookback_days = 2
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+
+    with patch("app.actions.handlers.get_auth_config", return_value=MagicMock()), \
+         patch("app.actions.handlers.client.get_projects", new_callable=AsyncMock, return_value=None):
+
+        result = await handlers.action_pull_observations(integration, action_config)
+        assert result["sensors_triggered"] == 0
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_bad_auth_exception(mocker, mock_publish_event):
+    integration = MagicMock()
+    integration.id = "int1"
+    integration.base_url = None
+
+    action_config = MagicMock()
+    action_config.sensor_featured_properties = None
+    action_config.default_lookback_days = 2
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+
+    unauthorized_exc = handlers.client.StevensConnectUnauthorizedException("error", "message")
+
+    with patch("app.actions.handlers.get_auth_config", return_value=MagicMock()), \
+         patch("app.actions.handlers.client.get_projects", new_callable=AsyncMock, side_effect=unauthorized_exc):
+
+        with pytest.raises(handlers.client.StevensConnectUnauthorizedException):
+            await handlers.action_pull_observations(integration, action_config)
+
+@pytest.mark.asyncio
+async def test_action_pull_sensor_observations_per_station_good(mocker, mock_publish_event):
+    integration = MagicMock()
+    integration.id = "int1"
+    integration.base_url = None
+
+    action_config = MagicMock()
+    action_config.sensor_featured_properties = []
+    action_config.sensor = {"name": "Sensor1"}
+    action_config.units = []
+    # Simulate sensor_observations
+    sensor_observations = {
+        "2024-01-01T00:00:00Z": [MagicMock(channel_id=1, reading=10)]
+    }
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+
+    with patch("app.actions.handlers.client.get_sensor_readings", new_callable=AsyncMock, return_value=sensor_observations), \
+         patch("app.actions.handlers.transform", return_value={}), \
+         patch("app.actions.handlers.generate_batches", return_value=[[{}]]), \
+         patch("app.actions.handlers.send_observations_to_gundi", new_callable=AsyncMock, return_value=[1]):
+
+        result = await handlers.action_pull_sensor_observations_per_station(integration, action_config)
+        assert result["observations_extracted"] == 1
+
+@pytest.mark.asyncio
+async def test_action_pull_sensor_observations_per_station_bad_no_observations(mocker, mock_publish_event):
+    integration = MagicMock()
+    integration.id = "int1"
+    integration.base_url = None
+
+    action_config = MagicMock()
+    action_config.sensor_featured_properties = []
+    action_config.sensor = {"name": "Sensor1"}
+    action_config.units = []
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+
+    with patch("app.actions.handlers.client.get_sensor_readings", new_callable=AsyncMock, return_value=None):
+
+        result = await handlers.action_pull_sensor_observations_per_station(integration, action_config)
+        assert result["observations_extracted"] == 0
+
+@pytest.mark.asyncio
+async def test_action_pull_sensor_observations_per_station_bad_auth_exception(mocker, mock_publish_event):
+    integration = MagicMock()
+    integration.id = "int1"
+    integration.base_url = None
+
+    action_config = MagicMock()
+    action_config.sensor_featured_properties = []
+    action_config.sensor = {"name": "Sensor1"}
+    action_config.units = []
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+
+    unauthorized_exc = handlers.client.StevensConnectUnauthorizedException("error", "message")
+
+    with patch("app.actions.handlers.client.get_sensor_readings", new_callable=AsyncMock, side_effect=unauthorized_exc):
+
+        with pytest.raises(handlers.client.StevensConnectUnauthorizedException):
+            await handlers.action_pull_sensor_observations_per_station(integration, action_config)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = app/actions/test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-testpaths = app/actions/tests
+testpaths = app/actions/test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-testpaths = app/actions/test
+testpaths = app/actions/tests


### PR DESCRIPTION
### Relevant Link:

https://allenai.atlassian.net/browse/GUNDI-4109

---

This pull request introduces support for configuring and displaying "featured" sensor properties in observation data, along with comprehensive unit tests for the client and handler logic. 

The changes allow users to specify which sensor readings should be highlighted, and ensure that these are properly parsed, processed, and included in the output. Additionally, new and expanded tests improve reliability and coverage for the client and handler modules.

**Support for featured sensor properties:**

* Added a new optional `sensor_featured_properties` field to `PullObservationsConfig` and `PullSensorObservationsPerStationConfig` to allow configuration of which sensor data should be displayed as "featured" (`app/actions/configurations.py`).
* Implemented parsing logic for the featured properties and integrated it into the observation pulling and transformation process, ensuring only the configured readings are highlighted in the output (`app/actions/handlers.py`) [[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L29-R40) [[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R61-R70) [[3]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L60-R81) [[4]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R109-R111) [[5]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R147) [[6]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113R156) [[7]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L174-R200).

**Testing improvements:**

* Added a new test suite for the client module, covering token retrieval, project fetching, and sensor reading retrieval with various success and error scenarios (`app/actions/tests/test_client.py`).
* Added a new test suite for the handlers module, testing observation pulling and sensor observation extraction, including edge cases and error handling (`app/actions/tests/test_handlers.py`).
* Configured pytest to look for tests in the correct directory (`pytest.ini`).

### How it looks?

[Config](https://stage.gundiservice.org/connections/f531f031-fa74-48f2-a85a-df3d75553a63/provider):

<img width="648" height="404" alt="image" src="https://github.com/user-attachments/assets/9dce2b24-1048-466b-aed6-e79199fb227c" />

---

[ER](https://gundi-dev.staging.pamdas.org/layers):

<img width="858" height="946" alt="image" src="https://github.com/user-attachments/assets/cf96c868-0c88-4d32-8644-004d08b28b6f" />
